### PR TITLE
Update commit hook to match new "advisory rules" files

### DIFF
--- a/hooks/commits.php
+++ b/hooks/commits.php
@@ -137,7 +137,7 @@ foreach ($commits as $commit) {
     $files_eol = array();
     foreach ($detail['files'] as $file) {
         if (preg_match("@\n\+[^\n]*\t@", $file['patch'])) {
-            if ($file['filename'] != 'libraries/advisory_rules.txt') {
+            if (!preg_match('^libraries/advisory_rules.*\.txt$', $file['filename'])) {
                 $files_tab[] = $file['filename'];
             }
         }


### PR DESCRIPTION
As I renamed the "advisory rules" files (see PR below), here is a proposal to match new file names.
This change should still match the old name, but also the new ones.
(This had been blind-coded, so if you have any chance to test it before accepting it, that would be nice, thanks.)

https://github.com/phpmyadmin/phpmyadmin/pull/15457
https://github.com/phpmyadmin/phpmyadmin/pull/15461