### PR TITLE
Remove demo version 4.9.x

### DIFF
--- a/demo/php/versions.ini
+++ b/demo/php/versions.ini
@@ -11,7 +11,6 @@ branches[] = master-config
 branches[] = master-http
 branches[] = master-config-nopmadb
 branches[] = STABLE
-branches[] = QA_4_9
 branches[] = QA_5_2
 
 # Version of future release from master branch


### PR DESCRIPTION
phpMyAdmin 4.9.x is in security maintenance only and it does not supports PHP 8.2, which is the PHP version used for the demo server.